### PR TITLE
이미지 파일 업로드시 정보를 가져오는 젬 버전을 변경합니다.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ gem 'rails-timeago', '~> 2.15'
 gem 'icalendar', '~> 2.5', '>= 2.5.3'
 
 # image
-gem 'exifr'
+gem 'exifr', '1.2.6'
 gem 'imgkit', '~> 1.6', '>= 1.6.1'
 group :development, :test do
   gem 'wkhtmltoimage-binary', '~> 0.12.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       activesupport (>= 4.0, < 7)
     excon (0.66.0)
     execjs (2.7.0)
-    exifr (1.3.6)
+    exifr (1.2.6)
     ey_config (0.0.7)
     faker (2.2.2)
       i18n (~> 1.6.0)
@@ -811,7 +811,7 @@ DEPENDENCIES
   dotenv-rails
   enumerize (~> 2.0)
   exception_notification (~> 4.1, >= 4.1.4)
-  exifr
+  exifr (= 1.2.6)
   ey_config
   faker
   fastimage (~> 1.9)


### PR DESCRIPTION
젬 업그레이드 bbb42e9 결과 이미지 정보를 가져오는 젬 exifr 1.3.6으로 업그레이드하였으나, 1.3.0 버전 이후로는 require exifr/jpeg 필요하여, uninitialized constant EXIFR::JPEG 오류가 발생하여 다운그레이드합니다.

참고
1. https://github.com/remvee/exifr/blob/master/CHANGELOG
1. https://meta.discourse.org/t/uninitialized-constant-when-uploading-jpg/89362/2
