### PR TITLE
댓글에 메일 주소를 입력할 때 끝이나 처음에 공백 문자를 넣어도 댓글이 잘 저장됩니다

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -21,10 +21,13 @@ class Comment < ApplicationRecord
   scope :earlier, -> { order(created_at: :asc) }
   scope :with_target_agent, ->(agent) { joins(:target_agents).where('orders.agent_id = ?', agent.id) }
 
+
   validates :body, presence: true
   validates :commenter_email, format: { with: Devise.email_regexp, message: :need_to_valid_email }, if: 'commenter_email.present?'
   validate :commenter_should_be_present_if_user_is_blank
   validate :photo_and_map_campaign_should_check_image_attachment
+
+  before_validation :strip_whitespace
   after_validation :fetch_geocode, if: ->(obj){ obj.full_street_address.present? and obj.full_street_address_changed? }
 
   attr_accessor :target_agent_id
@@ -99,4 +102,7 @@ class Comment < ApplicationRecord
     end
   end
 
+  def strip_whitespace
+    self.commenter_email = self.commenter_email.strip unless self.commenter_email.blank?
+  end
 end


### PR DESCRIPTION
현재 댓글에 메일 주소를 입력할 때 공백을 넣으면 이메일을 확인하라는 안내 메시지가 뜹니다.
validation하기 전에 공백을 제거하였습니다.