### PR TITLE
촉구 메일 전송 상태를 저장할 수 있습니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ $ source .powenv && bundle exec sidekiq
 
 puma를 재기동합니다
 
+### SES 반송 테스트
+
+ngrok 등을 이용, 로컬 웹서버를 외부에 오픈합니다.
+
+$ ngrok http -host-header=govcraft.test govcraft.test:80
+
+AWS SES의 해당 Email Address에서 Notifications 설정합니다.
+arn:aws:sns:***는 AWS SNS 구독 ID입니다.
+
+```
+Bounce Notifications SNS Topic:	arn:aws:sns:***
+  Include Original Headers:	enabled
+Complaint Notifications SNS Topic: arn:aws:sns:***
+  Include Original Headers: enabled
+```
+
+
 ### 조직 기본 데이터 등록
 
 ```

--- a/app/controllers/simple_mail_controller.rb
+++ b/app/controllers/simple_mail_controller.rb
@@ -34,7 +34,27 @@ class SimpleMailController < ApplicationController
           json['complaint']['complaintFeedbackType']
         else
         end
-      Order.where(id: order_ids).update_all(mailing_result_type: mailing_result_type, mailing_result_subtype: mailing_result_subtype)
+
+      recipients = case mailing_result_type
+        when 'Bounce'
+          json['bounce']['bouncedRecipients']
+        when 'Complaint'
+          json['complaint']['complainedRecipients']
+        else
+        end
+      if recipients.present? and recipients.any?
+        mailing_result_recipient = recipients.to_json
+      end
+
+      mailing_result_timestamp = case mailing_result_type
+        when 'Bounce'
+          json['bounce']['timestamp']
+        when 'Complaint'
+          json['complaint']['timestamp']
+        else
+        end
+
+      Order.where(id: order_ids).update_all(mailing_result_type: mailing_result_type, mailing_result_subtype: mailing_result_subtype, mailing_result_recipient: mailing_result_recipient, mailing_result_timestamp: mailing_result_timestamp)
     end
   end
 end

--- a/app/controllers/simple_mail_controller.rb
+++ b/app/controllers/simple_mail_controller.rb
@@ -1,0 +1,40 @@
+class SimpleMailController < ApplicationController
+  skip_before_action :verify_authenticity_token # so AWS callbacks are accepted
+
+  def callback
+    json = JSON.parse(request.raw_post)
+    logger.info "notification callback from AWS with #{json}"
+    aws_needs_url_confirmed = json['SubscribeURL']
+    if aws_needs_url_confirmed
+      logger.info "AWS is requesting confirmation of the notification handler URL"
+      uri = URI.parse(aws_needs_url_confirmed)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.get(uri.request_uri)
+    else
+      logger.info "AWS has sent us the notification(s)"
+
+      mail = json['mail']
+      return if mail.blank?
+
+      order_ids = []
+      begin
+        order_ids_json = mail['headers'].select { |header| header["name"] == 'X-PARTI-ORDERS' }.try(:first)
+        order_ids = JSON.parse(order_ids_json["value"]) if order_ids_json.present?
+      rescue
+      end
+      return if order_ids.blank?
+
+      mailing_result_type = json['notificationType']
+      mailing_result_subtype = case mailing_result_type
+        when 'Bounce'
+          "#{json['bounce']['bounceType']}::#{json['bounce']['bounceSubType']}"
+        when 'Complaint'
+          json['complaint']['complaintFeedbackType']
+        else
+        end
+      Order.where(id: order_ids).update_all(mailing_result_type: mailing_result_type, mailing_result_subtype: mailing_result_subtype)
+    end
+  end
+end

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -20,7 +20,6 @@ class CommentMailer < ApplicationMailer
       @orders << order
     end
 
-
     @agent = Agent.find_by(id: agent_id)
     return if @agent.blank?
 
@@ -39,11 +38,11 @@ class CommentMailer < ApplicationMailer
       end
     end
 
-    headers['X-PARTI-ORDERS'] = [@order.id].to_json
+    headers['X-PARTI-ORDERS'] = @orders.map(&:id).to_json
 
     mail(to: @agent.email,
-      template_name: template_name)
-    # mail(to: "complaint@simulator.amazonses.com",
+    template_name: template_name)
+    # mail(to: "bounce@simulator.amazonses.com",
     #   template_name: template_name, delivery_method: :aws_sdk)
   end
 end

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -39,7 +39,11 @@ class CommentMailer < ApplicationMailer
       end
     end
 
+    headers['X-PARTI-ORDERS'] = [@order.id].to_json
+
     mail(to: @agent.email,
       template_name: template_name)
+    # mail(to: "complaint@simulator.amazonses.com",
+    #   template_name: template_name, delivery_method: :aws_sdk)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
   get 'privacy', to: "pages#privacy", as: 'privacy'
   get 'terms', to: "pages#terms", as: 'terms'
 
+  post 'simple_mail/callback' => 'simple_mail#callback'
+
   resources :users
   resources :comments do
     get '/readers', on: :member, to: 'comments#readers'

--- a/db/migrate/20191022170525_add_mailing_result_to_orders.rb
+++ b/db/migrate/20191022170525_add_mailing_result_to_orders.rb
@@ -1,0 +1,6 @@
+class AddMailingResultToOrders < ActiveRecord::Migration[5.0]
+  def change
+    add_column :orders, :mailing_result_type, :string
+    add_column :orders, :mailing_result_subtype, :string
+  end
+end

--- a/db/migrate/20191103014131_add_additional_mailing_result_to_orders.rb
+++ b/db/migrate/20191103014131_add_additional_mailing_result_to_orders.rb
@@ -1,0 +1,6 @@
+class AddAdditionalMailingResultToOrders < ActiveRecord::Migration[5.0]
+  def change
+    add_column :orders, :mailing_result_timestamp, :string
+    add_column :orders, :mailing_result_recipient, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191029050430) do
+ActiveRecord::Schema.define(version: 20191103014131) do
 
   create_table "action_targets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.string  "action_assignable_id",   null: false
@@ -340,6 +340,7 @@ ActiveRecord::Schema.define(version: 20191029050430) do
     t.string   "use_signer_phone",                           default: "unused"
     t.string   "sign_placeholder"
     t.boolean  "need_stance",                                default: true
+    t.text     "default_statement_body",       limit: 65535
     t.index ["area_id"], name: "index_campaigns_on_area_id", using: :btree
     t.index ["issue_id"], name: "index_campaigns_on_issue_id", using: :btree
     t.index ["project_id"], name: "index_campaigns_on_project_id", using: :btree
@@ -676,11 +677,13 @@ ActiveRecord::Schema.define(version: 20191029050430) do
   create_table "orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.integer  "comment_id"
     t.integer  "agent_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
     t.datetime "read_at"
     t.string   "mailing_result_type"
     t.string   "mailing_result_subtype"
+    t.string   "mailing_result_timestamp"
+    t.string   "mailing_result_recipient"
     t.index ["agent_id"], name: "index_orders_on_agent_id", using: :btree
     t.index ["comment_id", "agent_id"], name: "comments_target_speakers_uk", unique: true, using: :btree
     t.index ["comment_id"], name: "index_orders_on_comment_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -676,9 +676,11 @@ ActiveRecord::Schema.define(version: 20191029050430) do
   create_table "orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.integer  "comment_id"
     t.integer  "agent_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.datetime "read_at"
+    t.string   "mailing_result_type"
+    t.string   "mailing_result_subtype"
     t.index ["agent_id"], name: "index_orders_on_agent_id", using: :btree
     t.index ["comment_id", "agent_id"], name: "comments_target_speakers_uk", unique: true, using: :btree
     t.index ["comment_id"], name: "index_orders_on_comment_id", using: :btree


### PR DESCRIPTION
모니터 하는 화면까지는 이번에 구현하지 말고
우선 각 요청별로 전송 / 반송 상태를 SES 에 받아 저장하는 정도로 마무리할까 합니다.

필요 시 서버 콘솔을 통해 수동 확인하면서 모니터 구현을 해보면 어떨까 합니다. 의견 바랍니다.

#78 
