### PR TITLE
서명에 촉구가 포함된 경우 촉구 설정을 할 수 있고 모든 캠페인에서 개인보호 정책 동의 문구를 넣을 수 있습니다.

### DIFF
--- a/app/views/campaigns/_form.html.haml
+++ b/app/views/campaigns/_form.html.haml
@@ -34,6 +34,9 @@
 
         = render_if_exist "campaigns/#{@campaign.template}/partial_form", f: f
 
+        - if @campaign.agents.any?
+          = render_if_exist "campaigns/order/partial_form", f: f
+
         %legend.m-t 추가 기능
 
         .form-group

--- a/app/views/campaigns/_form.html.haml
+++ b/app/views/campaigns/_form.html.haml
@@ -36,6 +36,13 @@
 
         %legend.m-t 추가 기능
 
+        .form-group
+          = f.label :confirm_privacy
+          %p.help-block
+            개인보호 정책 동의에 추가할 문구입니다.(선택사항)
+          ~ f.text_area :confirm_privacy, class: 'form-control redactor'
+
+
         - if @campaign.comment_disablable?
           .form-group
             .checkbox

--- a/app/views/campaigns/order/_partial_form.html.haml
+++ b/app/views/campaigns/order/_partial_form.html.haml
@@ -1,4 +1,3 @@
-
 %legend.m-t 촉구
 
 .form-group
@@ -28,10 +27,3 @@
     %label.radio-inline
       = f.radio_button :need_stance, false
       의견만 요구
-
-.form-group
-  = f.label :confirm_privacy
-  %p.help-block
-    개인보호 정책 동의에 추가할 문구입니다.(선택사항)
-  ~ f.text_area :confirm_privacy, class: 'form-control redactor'
-

--- a/app/views/campaigns/petition/_partial_form.html.haml
+++ b/app/views/campaigns/petition/_partial_form.html.haml
@@ -63,10 +63,3 @@
   = f.text_field :signer_phone_title, class: 'form-control'
   %p.help-block
     서명 영역의 연락처 입력폼 제목을 정합니다. 비워두면 적절히 표시됩니다.
-
-.form-group
-  = f.label :confirm_privacy
-  %p.help-block
-    개인보호 정책 동의에 추가할 문구입니다.(선택사항)
-  ~ f.text_area :confirm_privacy, class: 'form-control redactor'
-


### PR DESCRIPTION
모든 캠페인에서 개인보호 정책 동의 문구를 넣을 수 있게는 했는데요. 순전히 프로그래밍 편의 상이기도 하고 그게 캠페인 운영 기획의 의미 상으로도 단순해 보여서요. 모든 캠페인은 개인정보를 자체 수집할 수 있게 한다는 그런 의미요.

문제는 현재 실제 사용 가능한 곳이 촉구 캠페인과 서명 캠페인 뿐이란 거네요. 의견 주세요.

#100