### PR TITLE
촉구 대상자가 없으면 촉구탭을 비활성화합니다.

### DIFF
--- a/app/views/campaigns/_order_button_sticky.html.haml
+++ b/app/views/campaigns/_order_button_sticky.html.haml
@@ -1,4 +1,4 @@
-- if campaign.present? and !campaign.closed?
+- if campaign.present? and !campaign.closed? and @campaign.agents.any?
   %section.section-sign-btn.js-sticky-sign-button.stuck.hidden-sm.visible-xs-block
     = link_to [:new_comment_agent, campaign], class: "btn btn-danger btn-lg btn-block stuck sign-btn" do
       .sign-btn-text

--- a/app/views/campaigns/order/_section_right.html.haml
+++ b/app/views/campaigns/order/_section_right.html.haml
@@ -49,24 +49,24 @@
 
       - if @campaign.opened?
         .campaign-sign-form
-          = link_to [:new_comment_agent, @campaign], class: "btn btn-danger btn-lg btn-block campaign-sign-btn" do
-            촉구하기
-          - if @campaign.confirm_privacy.present?
-            .campaign-sign-privacy-policy
-              촉구하기를 누르시면 본 서명의
-              %a{ "data-target" => "#privacy-modal", "data-toggle" => "modal", :type => "button", style: 'cursor:pointer' }
-                개인정보취급방침
-              에 동의하게 됩니다.
-            #privacy-modal.modal.fade{:role => "dialog", :tabindex => "0"}
-              .modal-dialog{:role => "document"}
-                .modal-content
-                  .modal-header
-                    %button.close{"aria-label" => "Close", "data-dismiss" => "modal", :type => "button"}
-                      %span{"aria-hidden" => "true"} &#215;
-                    %h4.modal-title 개인정보취급방침
-                  .modal-body
-                    != @campaign.confirm_privacy
-
+          - if @campaign.agents.any?
+            = link_to [:new_comment_agent, @campaign], class: "btn btn-danger btn-lg btn-block campaign-sign-btn" do
+              촉구하기
+            - if @campaign.confirm_privacy.present?
+              .campaign-sign-privacy-policy
+                촉구하기를 누르시면 본 서명의
+                %a{ "data-target" => "#privacy-modal", "data-toggle" => "modal", :type => "button", style: 'cursor:pointer' }
+                  개인정보취급방침
+                에 동의하게 됩니다.
+              #privacy-modal.modal.fade{:role => "dialog", :tabindex => "0"}
+                .modal-dialog{:role => "document"}
+                  .modal-content
+                    .modal-header
+                      %button.close{"aria-label" => "Close", "data-dismiss" => "modal", :type => "button"}
+                        %span{"aria-hidden" => "true"} &#215;
+                      %h4.modal-title 개인정보취급방침
+                    .modal-body
+                      != @campaign.confirm_privacy
 
       .more{ style: 'text-align: center; margin: 1em 0 0;' }
         = link_to '자세히 보기...', orders_campaign_path(@campaign), style: 'color: gray'

--- a/app/views/campaigns/order/_section_tab.html.haml
+++ b/app/views/campaigns/order/_section_tab.html.haml
@@ -3,9 +3,14 @@
     %li{ class: [menu == 'content' && "active"] }
       .menu-item
         = link_to '내용', campaign_path
-    %li{ class: [menu == 'order' && "active"]  }
-      .menu-item
-        = link_to '촉구', orders_campaign_path
+    - if @campaign.agents.any?
+      %li{ class: [menu == 'order' && "active"]  }
+        .menu-item
+          = link_to '촉구', orders_campaign_path
+    - else
+      %li{ 'data-toggle' => 'tooltip',  'data-placement' => 'top', 'data-boundary' => 'viewport', 'title' => '촉구 대상을 등록하겠습니다. 잠시 기다려주세요' }
+        .menu-item
+          = link_to '촉구', '#'
     %li{ class: [menu == 'comment' && "active"]  }
       .menu-item
         = link_to comments_campaign_path do
@@ -15,4 +20,3 @@
               = number_with_limit(@campaign.comments.size, 1000)
     %li{ class: [menu == 'story' && "active"] }
       = link_to '소식', stories_campaign_path
-

--- a/app/views/campaigns/order/orders.html.haml
+++ b/app/views/campaigns/order/orders.html.haml
@@ -7,31 +7,35 @@
 
   %section.section-left
     %section.section-orders-tab.section-orders-tab-special-agenda
-      .orders-tab-title
+      - agents_count = @campaign.agents.count
+      - if agents_count > 0
+        .orders-tab-title
+          - if @campaign.opened?
+            지금 #{@campaign.agents_shuffled.first.name}
+            - if agents_count > 1
+              외 #{agents_count - 1}
+            대상에게 촉구해 주세요
+          - else
+            캠페인 촉구
+
+        .orders-tab-title-h5 촉구 응답 현황
+        = render 'campaigns/order_dashboard', campaign: @campaign
+        = render 'campaigns/agents_with_statement', campaign: @campaign
+
         - if @campaign.opened?
-          지금 #{@campaign.agents_shuffled.first.name}
-          - agents_count = @campaign.agents.count
-          - if agents_count > 1
-            외 #{agents_count - 1}
-          대상에게 촉구해 주세요
-        - else
-          캠페인 촉구
+          .orders-tab-title-h5.title-wrap
+            .title-left 촉구하기
+            .title-right
+              .response-header-text
+                촉구 대상 중 한 분인가요?
+              = link_to [:edit_statements, @campaign], class: 'response-header-btn' do
+                답변하기
 
-      .orders-tab-title-h5 촉구 응답 현황
-      = render 'campaigns/order_dashboard', campaign: @campaign
-      = render 'campaigns/agents_with_statement', campaign: @campaign
-
-      - if @campaign.opened?
-        .orders-tab-title-h5.title-wrap
-          .title-left 촉구하기
-          .title-right
-            .response-header-text
-              촉구 대상 중 한 분인가요?
-            = link_to [:edit_statements, @campaign], class: 'response-header-btn' do
-              답변하기
-
-        - agents = @campaign.agents.order(name: :asc).page(1).per(10)
-        - if agents.any?
-          = render 'campaigns/agents_page', campaign: @campaign, agents: agents, next_path: agents_campaign_path(@campaign, page: agents.next_page)
+          - agents = @campaign.agents.order(name: :asc).page(1).per(10)
+          - if agents.any?
+            = render 'campaigns/agents_page', campaign: @campaign, agents: agents, next_path: agents_campaign_path(@campaign, page: agents.next_page)
+      - else
+        .orders-tab-title
+          촉구 대상을 등록하겠습니다. 잠시 기다려주세요
 
 = render 'campaigns/order_button_sticky', campaign: @campaign

--- a/app/views/campaigns/order_assembly/_section_right.html.haml
+++ b/app/views/campaigns/order_assembly/_section_right.html.haml
@@ -49,8 +49,9 @@
 
       - if @campaign.opened?
         .campaign-sign-form
-          = link_to [:new_comment_agent, @campaign], class: "btn btn-danger btn-lg btn-block campaign-sign-btn" do
-            촉구하기
+          - if @campaign.agents.any?
+            = link_to [:new_comment_agent, @campaign], class: "btn btn-danger btn-lg btn-block campaign-sign-btn" do
+              촉구하기
 
       .more{ style: 'text-align: center; margin: 1em 0 0;' }
         = link_to '자세히 보기...', orders_campaign_path(@campaign), style: 'color: gray'


### PR DESCRIPTION
촉구하는 캠페인에 촉구 대상자를 넣기 전에 캠페인 섹션 탭의 촉구 링크를 막습니다. 만약 사용자가 촉구 탭을 직접 url 입력하여 접속하는 경우, '촉구 대상을 등록하겠습니다. 잠시 기다려주세요'라는 안내문을 표시합니다. #107 

참고.https://campaigns.kr/campaigns/197