### PR TITLE
모바일에서 입력한 촉구 내용이나 댓글 내용의 줄바꿈이 내용을 확인할 때도 그대로 유지됩니다 #101

### DIFF
--- a/app/assets/stylesheets/_campaigns.scss
+++ b/app/assets/stylesheets/_campaigns.scss
@@ -755,6 +755,9 @@
           margin: 12px 0;
           padding: 8px;
           width: 140px;
+          @media (max-width: $screen-xs-max) {
+            width: 120px;
+          }
           height: 32px;
         }
       }

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -110,6 +110,7 @@ class CampaignsController < ApplicationController
 
   def order_form
     @comment = Comment.new
+    @comment.is_html_body = true
     @comment.body = (@campaign.message_to_agent || '') + "<p></p>"
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -82,8 +82,9 @@ class CommentsController < ApplicationController
 
     @comment.confirm_privacy = true if @comment.commentable.try(:confirm_privacy).present?
 
-    unless helpers.is_redactorable?
-      @comment.body = ApplicationController.helpers.simple_format(ERB::Util.h(@comment.body), {}, sanitize: false)
+    unless @comment.is_html_body?
+      @comment.body = ApplicationController.helpers.smart_format(@comment.body)
+      @comment.is_html_body = true
     end
 
     if @comment.save
@@ -171,7 +172,7 @@ class CommentsController < ApplicationController
       :tag_list, :image,
       :target_agent_id, :mailing,
       :toxic,
-      :test, :comment_user_id
+      :test, :comment_user_id, :is_html_body
     )
   end
 end

--- a/app/controllers/concerns/statementing.rb
+++ b/app/controllers/concerns/statementing.rb
@@ -50,6 +50,7 @@ module Statementing
     @statementable = fetch_statementable
     @comment = Comment.new
     if @statementable.respond_to? :message_to_agent
+      @comment.is_html_body = true
       @comment.body = (@statementable.message_to_agent || '') + "<p></p>"
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,14 +55,6 @@ module ApplicationHelper
     end
   end
 
-  def smart_format(text, html_options = {}, options = {})
-    parsed_text = simple_format(h(text), html_options, options).to_str
-    raw(auto_link(parsed_text,
-      html: {class: 'auto_link', target: '_blank'},
-      link: :urls,
-      sanitize: false))
-  end
-
   def asset_data_base64(path)
     content, content_type = parse_asset(path)
     base64 = Base64.encode64(content).gsub(/\s+/, "")

--- a/app/helpers/smart_text_helper.rb
+++ b/app/helpers/smart_text_helper.rb
@@ -1,0 +1,9 @@
+module SmartTextHelper
+  def smart_format(text, html_options = {}, options = {})
+    parsed_text = simple_format(ERB::Util.html_escape(text), html_options, options).to_str
+    raw(auto_link(parsed_text,
+      html: {class: 'auto_link', target: '_blank'},
+      link: :urls,
+      sanitize: false))
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,9 @@ class Comment < ApplicationRecord
   include Choosable
   include Reportable
 
+  include ActionView::Helpers::TextHelper
+  include SmartTextHelper
+
   extend Enumerize
   enumerize :mailing, in: %i(disable ready sent fail)
 
@@ -84,6 +87,14 @@ class Comment < ApplicationRecord
       self.longitude = address["x"]
       self.latitude = address["y"]
     rescue
+    end
+  end
+
+  def smart_body(htmlable = true)
+    if htmlable
+      self.is_html_body ? self.body : smart_format(self.body)
+    else
+      self.is_html_body ? Html2Text.convert(self.body) : self.body
     end
   end
 

--- a/app/views/campaigns/_order_form.html.haml
+++ b/app/views/campaigns/_order_form.html.haml
@@ -26,9 +26,8 @@
                 = f.text_field :commenter_email, class: 'form-control'
             .form-group
               = f.label :body, "보내는 내용"
-              - unless is_redactorable?
-                - f.object.body = strip_tags(f.object.body)
-              ~ f.text_area :body, placeholder: '촉구합니다...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
+              = f.hidden_field :is_html_body, value: is_redactorable?
+              ~ f.text_area :body, value: f.object.smart_body(is_redactorable?), placeholder: '촉구합니다...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
             - if agent.email.present?
               .form-group
                 .checkbox

--- a/app/views/campaigns/order/orders.html.haml
+++ b/app/views/campaigns/order/orders.html.haml
@@ -6,7 +6,7 @@
   = render 'campaigns/order/section_right'
 
   %section.section-left
-    %section.section-orders-tab.section-orders-tab-special-agenda
+    %section.section-orders.section-orders-tab.section-orders-tab-special-agenda
       - agents_count = @campaign.agents.count
       - if agents_count > 0
         .orders-tab-title

--- a/app/views/campaigns/order_assembly/orders.html.haml
+++ b/app/views/campaigns/order_assembly/orders.html.haml
@@ -6,7 +6,7 @@
   = render 'campaigns/order_assembly/section_right'
 
   %section.section-left
-    %section.section-orders-tab.section-orders-tab-special-agenda
+    %section.section-orders.section-orders-tab.section-orders-tab-special-agenda
       .orders-tab-title
         - if @campaign.closed?
           국회의원에게 보낸 "#{@campaign.title}"의 응답 현황입니다.

--- a/app/views/campaigns/picket/_picket_form.html.haml
+++ b/app/views/campaigns/picket/_picket_form.html.haml
@@ -21,7 +21,10 @@
           = f.text_field :full_street_address, class: 'form-control'
       .form-group
         = f.label :body, '나도 한마디'
-        ~ f.text_area :body, placeholder: '여러분의 목소리를 들려주세요', class: 'form-control input-lg', data: { 'rule-required': true }
+        = f.hidden_field :is_html_body, value: is_redactorable?
+        - unless is_redactorable?
+          - f.object.body = Html2Text.convert(f.object.body)
+        ~ f.text_area :body, placeholder: '여러분의 목소리를 들려주세요', class: 'form-control input-lg validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
       .form-group
         = f.text_field :tag_list, placeholder: '태그, 태그를 입력해주세요', class: 'form-control'
       .form-group

--- a/app/views/campaigns/special_any_speech/_show.html.haml
+++ b/app/views/campaigns/special_any_speech/_show.html.haml
@@ -89,7 +89,10 @@
                         = f.label :commenter_email
                         = f.text_field :commenter_email, class: 'form-control'
                 .form-group
-                  ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), data: { 'rule-required': true }
+                  = f.hidden_field :is_html_body, value: is_redactorable?
+                  - unless is_redactorable?
+                    - f.object.body = Html2Text.convert(f.object.body)
+                  ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
                 .form-group
                   = f.label :full_street_address, '주소(필수)'
                   = f.select :full_street_address, options_for_select(Campaign::LARGE_AREA), {}, class: 'form-control'

--- a/app/views/campaigns/special_map_with_assembly/_show.html.haml
+++ b/app/views/campaigns/special_map_with_assembly/_show.html.haml
@@ -59,7 +59,10 @@
       = f.label :image
       = f.file_field :image, class: 'form-control'
     .form-group
-      ~ f.text_area :body, placeholder: '지금 나는...', required: true, rows: 3, class: 'form-control', data: { 'rule-required': true }
+      = f.hidden_field :is_html_body, value: is_redactorable?
+      - unless is_redactorable?
+        - f.object.body = Html2Text.convert(f.object.body)
+      ~ f.text_area :body, placeholder: '지금 나는...', required: true, rows: 3, class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
     = f.submit '작성', class: 'btn btn-primary btn-block'
 %section.page-block
   .container
@@ -83,7 +86,8 @@
                   - else
                     = image_tag comment.image.lg.url, style: 'width: 100%;'
               .comment__body
-                %h4{ style: 'font-size: 16px; letter-spacing: -0.02em; line-height: 1.4;'}= smart_format comment.body
+                %h4{ style: 'font-size: 16px; letter-spacing: -0.02em; line-height: 1.4;'}
+                  != comment.smart_body
               .comment__meta{ style: 'color: #5f5f5f;font-size: 12px' }
                 - if comment.latitude && comment.longitude
                   %i.fa.fa-map-marker.text-danger

--- a/app/views/campaigns/special_speech/_show.html.haml
+++ b/app/views/campaigns/special_speech/_show.html.haml
@@ -89,7 +89,10 @@
                         = f.label :commenter_email
                         = f.text_field :commenter_email, class: 'form-control'
                 .form-group
-                  ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), data: { 'rule-required': true }
+                  = f.hidden_field :is_html_body, value: is_redactorable?
+                  - unless is_redactorable?
+                    - f.object.body = Html2Text.convert(f.object.body)
+                  ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
                 .form-group
                   = f.label :full_street_address, '주소(필수)'
                   = f.select :full_street_address, options_for_select(Campaign::LARGE_AREA), {}, class: 'form-control'

--- a/app/views/comment_mailer/target_agent_campaign.html.haml
+++ b/app/views/comment_mailer/target_agent_campaign.html.haml
@@ -34,7 +34,7 @@
   %p
     이 캠페인에 대해 #{comment.user_nickname}님이 #{@agent.name}님에게 행동을 촉구합니다.
   .container
-    != comment.body
+    != comment.smart_body
 
   %p
     &nbsp;

--- a/app/views/comments/_form_modal.html.haml
+++ b/app/views/comments/_form_modal.html.haml
@@ -20,7 +20,10 @@
                 = f.label :commenter_email
                 = f.text_field :commenter_email, class: 'form-control'
             .form-group
-              ~ f.text_area :body, placeholder: '제 생각은...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), data: { 'rule-required': true }
+              = f.hidden_field :is_html_body, value: is_redactorable?
+              - unless is_redactorable?
+                - f.object.body = Html2Text.convert(f.object.body)
+              ~ f.text_area :body, placeholder: '제 생각은...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
             - if commentable.try(:confirm_privacy).present?
               .form-group
                 .campaign-sign-privacy-policy

--- a/app/views/comments/_list.html.haml
+++ b/app/views/comments/_list.html.haml
@@ -18,7 +18,10 @@
               = f.label :commenter_email
               = f.text_field :commenter_email, class: 'form-control'
       .form-group
-        ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), data: { 'rule-required': true }
+        = f.hidden_field :is_html_body, value: is_redactorable?
+        - unless is_redactorable?
+          - f.object.body = Html2Text.convert(f.object.body)
+        ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
       = f.submit '의견 작성하기', class: 'btn btn-default btn-comment'
 
 = render 'comments/page', local_assigns.merge(comments: comments)

--- a/app/views/comments/_page_formal.html.haml
+++ b/app/views/comments/_page_formal.html.haml
@@ -58,7 +58,7 @@
 
                 .date= date_f comment.updated_at
             .comment-body
-              = raw comment.body
+              != comment.smart_body
             .comment-footer
               .comment-controls
                 - if can? :destroy, comment

--- a/app/views/comments/_picket.html.haml
+++ b/app/views/comments/_picket.html.haml
@@ -38,7 +38,7 @@
 
                 .date= date_f comment.updated_at
             .comment-body
-              = raw comment.body
+              != comment.smart_body
             .comment-footer
               = render 'likes/button', likable: comment
   - if !comments.last_page? and !local_assigns[:finite]

--- a/app/views/statementing/_agent.html.haml
+++ b/app/views/statementing/_agent.html.haml
@@ -41,7 +41,10 @@
                   = f.label :commenter_email, agent.email.present? ? "이메일(#{agent.name}님에게 메일을 발송하려면 반드시 넣어주세요)" : nil
                   = f.text_field :commenter_email, class: 'form-control'
               .form-group
-                ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), data: { 'rule-required': true }
+                = f.hidden_field :is_html_body, value: is_redactorable?
+                - unless is_redactorable?
+                  - f.object.body = Html2Text.convert(f.object.body)
+                ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
               - if agent.email.present?
                 .form-group
                   .checkbox

--- a/app/views/statementing/new_comment_agent.html.haml
+++ b/app/views/statementing/new_comment_agent.html.haml
@@ -33,9 +33,10 @@
               = f.text_field :commenter_email, class: 'form-control'
           .form-group
             = f.label :body, "보내는 내용"
+            = f.hidden_field :is_html_body, value: is_redactorable?
             - unless is_redactorable?
-              - f.object.body = strip_tags(f.object.body)
-            ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), data: { 'rule-required': true }
+              - f.object.body = Html2Text.convert(f.object.body)
+            ~ f.text_area :body, placeholder: '제 생각에는...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }
           - if @agent.email.present?
             .form-group
               .checkbox

--- a/app/views/statementing/new_comment_agent_for_all.html.haml
+++ b/app/views/statementing/new_comment_agent_for_all.html.haml
@@ -31,6 +31,7 @@
                   = f.text_field :commenter_email, class: 'form-control'
           .form-group
             = f.label :body, "보내는 내용"
+            = f.hidden_field :is_html_body, value: is_redactorable?
             - unless is_redactorable?
               - f.object.body = Html2Text.convert(f.object.body)
             ~ f.text_area :body, placeholder: '촉구합니다...', class: 'form-control validate ' + ( is_redactorable? ? 'redactor' : ''), style: 'height: 150px', data: { 'rule-required': true }

--- a/db/migrate/20191127044222_add_is_html_body_of_comments.rb
+++ b/db/migrate/20191127044222_add_is_html_body_of_comments.rb
@@ -1,0 +1,13 @@
+class AddIsHtmlBodyOfComments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :comments, :is_html_body, :boolean, default: false, null: false
+
+    reversible do |dir|
+      dir.up do
+        transaction do
+          execute "UPDATE comments SET is_html_body = 1 WHERE body like '%<p>%';"
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191125152531) do
+ActiveRecord::Schema.define(version: 20191127044222) do
 
   create_table "action_targets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.string  "action_assignable_id",   null: false
@@ -388,6 +388,7 @@ ActiveRecord::Schema.define(version: 20191125152531) do
     t.integer  "orders_count",                        default: 0
     t.integer  "comments_count",                      default: 0
     t.boolean  "confirm_privacy",                     default: false
+    t.boolean  "is_html_body",                        default: false, null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id", using: :btree
     t.index ["target_agent_id"], name: "index_comments_on_target_agent_id", using: :btree
     t.index ["user_id"], name: "index_comments_on_user_id", using: :btree


### PR DESCRIPTION
기존에 그냥 text로 입력된 댓글을 html로 변형하지 않고 보여줄 때마다 html로 바꾸어 표시합니다